### PR TITLE
Fix for older versions of Pathlib

### DIFF
--- a/pysi/sim/grid.py
+++ b/pysi/sim/grid.py
@@ -37,7 +37,7 @@ def add_parameter(
         raise OSError(f"provided file path {filepath} is not a .pf parameter file")
     if backup_original:
         copyfile(filepath, filepath + ".bak")
-    with Path.open(filepath, encoding="utf-8") as f:
+    with Path(filepath).open(encoding="utf-8") as f:
         lines = f.readlines()
 
     # Get the parameters and values into a list. Removes blank lines and
@@ -55,7 +55,7 @@ def add_parameter(
         where = names.index(insert_after) + 1 if insert_after else len(names)
         names.insert(where, parameter_name)
         values.insert(where, parameter_value)
-        with Path.open(filepath, "w", encoding="utf-8") as f:
+        with Path(filepath).open(mode="w", encoding="utf-8") as f:
             for name, value in zip(names, values, strict=True):
                 f.write(f"{name:40s} {value}\n")
 
@@ -82,7 +82,7 @@ def get_parameter_value(filepath: str, parameter_name: str) -> str:
     """
     if filepath.find(".pf") == -1:
         raise OSError(f"Provided file path {filepath} is not to a parameter file")
-    with Path.open(filepath, encoding="utf-8") as file_in:
+    with Path(filepath).open(encoding="utf-8") as file_in:
         lines = file_in.readlines()
 
     value = None
@@ -122,7 +122,7 @@ def update_parameter_value(
         raise OSError(f"The provided file path {filepath} is not to a parameter file")
     if backup_original:
         copyfile(filepath, filepath + ".bak")
-    with Path.open(filepath, encoding="utf-8") as file_in:
+    with Path(filepath).open(encoding="utf-8") as file_in:
         lines = file_in.readlines()
 
     old = ""
@@ -136,7 +136,7 @@ def update_parameter_value(
     if not old and not new:
         raise ValueError(f"Could not find the parameter {parameter_name} in {filepath}")
 
-    with Path.open(filepath, mode="w", encoding="utf-8") as file_out:
+    with Path(filepath).open(mode="w", encoding="utf-8") as file_out:
         file_out.writelines(lines)
 
 

--- a/pysi/spec/model/base.py
+++ b/pysi/spec/model/base.py
@@ -63,8 +63,6 @@ class SpectrumBase:
         self.set_scale(self.scaling)
         self.set_spectrum(self.current)
 
-        self._original_spectra = None
-
         if smooth_width:
             self.smooth_all_spectra(smooth_width)
 
@@ -186,7 +184,7 @@ class SpectrumBase:
             The contents of the file, as a list of the sentences split.
 
         """
-        with Path.open(file, encoding="utf-8") as file_in:
+        with Path(file).open(encoding="utf-8") as file_in:
             spectrum_file = file_in.readlines()
 
         contents = []
@@ -433,22 +431,12 @@ class SpectrumBase:
             The width of the boxcar filter.
 
         """
-        if not self._original_spectra:
-            self._original_spectra = copy.deepcopy(self.spectra)
-
         for scaling, spec_types in self.spectra.items():
             for spec_type, spec in spec_types.items():
                 for thing, values in spec.items():
                     if isinstance(values, numpy.ndarray) and thing not in ["Freq.", "Lambda"]:
                         # pylint: disable=unnecessary-dict-index-lookup
                         self.spectra[scaling][spec_type][thing] = array.smooth_array(values, boxcar_width)
-
-    def unsmooth_all_spectra(self) -> None:
-        """Reset the spectra to the original unsmoothed versions."""
-        if not self._original_spectra:
-            return
-
-        self.spectra = copy.deepcopy(self._original_spectra)
 
     def load_spectra(
         self, files_to_read: str | Iterable[str] = ("spec", "spec_tot", "spec_tot_wind", "spec_wind", "spec_tau")

--- a/pysi/util/run.py
+++ b/pysi/util/run.py
@@ -46,7 +46,7 @@ def run_windsave2table(  # noqa: PLR0913
     name = "windsave2table"
     if version:
         name += version
-        with Path.open(f"{file_path}/.sirocco-version", "w") as file_out:
+        with Path(f"{file_path}/.sirocco-version").open(mode="w", encoding="utf-8") as file_out:
             file_out.write(f"{version}\n")
 
     in_path = which(name)
@@ -138,13 +138,13 @@ def run_py_wind(root: str, commands: list[str], file_path: Path | str = Path()) 
     """
     cmd_file = f"{file_path}/.tmpcmds.txt"
 
-    with Path.open(cmd_file, "w", encoding="utf-8") as file_out:
+    with Path(cmd_file).open(mode="w", encoding="utf-8") as file_out:
         for command in commands:
             file_out.write(f"{command}\n")
 
     # This isn't using `run_shell_command` because we also need to pass stdin,
     # which is not what we want to do with that function.
-    with Path.open(cmd_file, "r", encoding="utf-8") as stdin:
+    with Path(cmd_file).open(encoding="utf-8") as stdin:
         sh_out = run(["py_wind", root], stdin=stdin, capture_output=True, cwd=file_path, check=True)  # noqa: S603, S607
 
     Path(cmd_file).unlink()

--- a/pysi/wind/model/plot.py
+++ b/pysi/wind/model/plot.py
@@ -472,7 +472,7 @@ class WindPlot(util.WindUtil):
             title = ""
             parameter_points = thing
         elif isinstance(thing, str):
-            title = thing
+            title = thing.replace("_", r" ")
             parameter_points = self[thing]
         else:
             raise TypeError(f"Unsupported type {type(self.parameters)} for plotting parameter")
@@ -480,9 +480,9 @@ class WindPlot(util.WindUtil):
         if log_parameter:
             with numpy.errstate(over="ignore", divide="ignore"):
                 parameter_points = numpy.log10(parameter_points)
-            ax[a_idx, a_jdx].set_title(r"$\log_{10}(" + f"{title})$")
+            ax[a_idx, a_jdx].set_title(r"$\log_{10}(" + rf"{title})$")
         else:
-            ax[a_idx, a_jdx].set_title(f"{title}")
+            ax[a_idx, a_jdx].set_title(rf"{title}")
 
         im = ax[a_idx, a_jdx].pcolormesh(
             x_points,

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,13 @@
-<<<<<<< HEAD
-#!/usr/bin/env python3
-
-from setuptools import find_packages, setup
-
-# get requirements from file
-with open("requirements.txt", encoding="utf-8") as file_in:
-    requirements = [line.strip("\n") for line in file_in.readlines()]
-# get version from pysi/__init__.py
-with open("pysi/__init__.py", encoding="utf-8") as file_in:
-    lines = file_in.readlines()
-for line in lines:
-    line = line.split()
-    if len(line) < 1:
-        continue
-    if line[0] == "__version__":
-        __version__ = str(line[2]).strip('"').strip("'")
-=======
 from pathlib import Path
 
 from setuptools import find_packages, setup
 
 # Get requirements from file
-with Path.open("requirements.txt", encoding="utf-8") as file_in:
+with Path("requirements.txt").open(encoding="utf-8") as file_in:
     requirements = [line.strip("\n") for line in file_in]
 
 # Get the library version fomr __version__.py
-with Path.open("pysi/__init__.py", encoding="utf-8") as file_in:
+with Path("pysi/__init__.py").open(encoding="utf-8") as file_in:
     for line_in in file_in:
         line = line_in.split()
         if len(line) < 1:
@@ -33,7 +15,6 @@ with Path.open("pysi/__init__.py", encoding="utf-8") as file_in:
         if line[0] == "__version__":
             __version__ = str(line[2]).strip('"').strip("'")
 
->>>>>>> main
 # setup function
 setup(
     name="PySi",


### PR DESCRIPTION
This PR merges a fix for older versions of Pathlib when using pathlib.Path.open(). It also removes Spectrum.unsmooth_spectrum() as it was never used and often caused issues (read: I didn't know how to fix a series of bugs).